### PR TITLE
Remove let keywords from the compiled file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": ["es2015"],
+    "plugins": [
+        "transform-es2015-block-scoping"
+    ]
+}

--- a/dist/vue-smoothscroll.js
+++ b/dist/vue-smoothscroll.js
@@ -54,19 +54,21 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	
+	"use strict";
 
-	let SmoothScroll = __webpack_require__(1);
+	var SmoothScroll = __webpack_require__(1);
 
 	module.exports = {
-	    install(Vue, options = { name: 'smoothscroll' }) {
+	    install: function install(Vue) {
+	        var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : { name: 'smoothscroll' };
+
 	        Vue.directive(options.name, {
-	            inserted(el, binding) {
+	            inserted: function inserted(el, binding) {
 	                SmoothScroll(el, binding.value["duration"], binding.value["callback"], binding.value["context"]);
 	            }
 	        });
 	        Object.defineProperty(Vue.prototype, '$SmoothScroll', {
-	            get: function () {
+	            get: function get() {
 	                return SmoothScroll;
 	            }
 	        });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "devDependencies": {
         "babel-core": "^6.17.0",
         "babel-loader": "^6.2.5",
+        "babel-plugin-transform-es2015-block-scoping": "^6.18.0",
         "babel-preset-es2015": "^6.16.0",
         "css-loader": "^0.25.0",
         "style-loader": "^0.13.1",


### PR DESCRIPTION
This PR relates to issue #3. It compiles the JS file to ES2015 standards and remove the `let` keyword.

Could you please review it and accept it if OK on your side? Then push it to npm.

Thanks!
Jerome