### PR TITLE
Add back options parameters

### DIFF
--- a/dist/vue-smoothscroll.js
+++ b/dist/vue-smoothscroll.js
@@ -56,7 +56,8 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var SmoothScroll = __webpack_require__(1);
 	module.exports = {
-	    install: function (Vue) {
+	    install: function (Vue, options) {
+	        options = options || { name: 'smoothscroll' };
 	        Vue.directive(options.name, {
 	            inserted: function (el, binding) {
 	                SmoothScroll(el, binding.value["duration"], binding.value["callback"], binding.value["context"]);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var SmoothScroll = require("smoothscroll")
 module.exports = {
-    install: function(Vue) {
+    install: function(Vue, options) {
+        options = options || { name: 'smoothscroll' };
         Vue.directive(options.name, {
             inserted: function(el, binding) {
                 SmoothScroll(el, binding.value["duration"], binding.value["callback"], binding.value["context"])


### PR DESCRIPTION
Hello,

When transitioning from ES2015 to "standard" javasvript, you removed the `options` parameter. I added it back in this pull request, with the same default value as before.

Please check and tell me if anything is missing. This is referring to issue #7.

Thanks,
Jerome